### PR TITLE
Update codecompass.rb for v0.0.1-beta.3

### DIFF
--- a/Formula/codecompass.rb
+++ b/Formula/codecompass.rb
@@ -1,8 +1,8 @@
 class Codecompass < Formula
   desc "A CLI tool that helps you navigate and understand large codebases."
   homepage "https://github.com/xeoncross/codecompass"
-  url "https://github.com/xeoncross/codecompass/archive/refs/tags/v0.0.1.tar.gz" # Placeholder: Update with each release
-  sha256 "0000000000000000000000000000000000000000000000000000000000000000" # Placeholder: Update with each release
+  url "https://github.com/xeon-zolt/codecompass/archive/refs/tags/v0.0.1-beta.3.tar.gz" # Placeholder: Update with each release
+  sha256 "99e7d4be71d3383faa6d00ead8f94c311b4c57b7f549e51ab2191ca58296e72f" # Placeholder: Update with each release
 
   depends_on "go" => :build
 


### PR DESCRIPTION
This PR updates the Homebrew formula for codecompass to version v0.0.1-beta.3.

Changes:
- Updated URL to point to v0.0.1-beta.3 tag
- Updated SHA256 checksum
- Corrected repository owner from xeoncross to xeon-zolt

Generated automatically by the Release workflow.